### PR TITLE
Add option to use named AWS profile

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -60,7 +60,12 @@ def run_benchmark(args):
     :return: None.
     """
 
-    lambda_client = boto3.client('lambda', region_name=args.region)
+    if args.aws_profile:
+        aws_session = boto3.Session(profile_name=args.aws_profile)
+    else:
+        aws_session = boto3.Session()
+
+    lambda_client = aws_session.client('lambda', region_name=args.region)
     sorted_memory_sizes = sorted(MEMORY_TO_PRICE)
     results = {}
 
@@ -150,6 +155,13 @@ if __name__ == '__main__':
         default=False,
         required=True,
         help='JSON Payload filename to send to the function.'
+    )
+    parser.add_argument(
+        '--profile',
+        dest='aws_profile',
+        default=False,
+        required=False,
+        help='A specific AWS Named Profile configured within your AWS Credentials file.'
     )
     parser.add_argument(
         '--output',


### PR DESCRIPTION
Great tool, very useful!

I use Named Profiles a lot to force me to explicitly state which AWS account I am performing actions in, as a result, I do not have a [default] section in my ~/.aws/credentials file, which causes issues with boto3 as it doesn't know what to use.

This PR adds a CLI option for the benchmark program for users to specify which AWS Named Profile they optionally wish to use. It has been tested with no profile specified and a named profile.
